### PR TITLE
Add unit tests for auth dependencies and password helpers

### DIFF
--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -1,0 +1,80 @@
+import pytest
+from fastapi import HTTPException
+
+from src.utils.dependencies import get_current_user_api_key, require_roles
+from src.repositories.utilisateur_repository import UtilisateurRepository
+
+
+class DummyRole:
+    def __init__(self, libelle_role: str):
+        self.libelle_role = libelle_role
+
+
+class DummyUser:
+    def __init__(self, role: DummyRole):
+        self.role = role
+
+
+def test_get_current_user_api_key_disabled_auth(monkeypatch):
+    monkeypatch.setenv("DISABLE_AUTH", "true")
+
+    assert get_current_user_api_key(api_key=None, db=None) is None
+
+
+def test_get_current_user_api_key_missing_key(monkeypatch):
+    monkeypatch.setenv("DISABLE_AUTH", "false")
+
+    with pytest.raises(HTTPException) as excinfo:
+        get_current_user_api_key(api_key=None, db=None)
+
+    assert excinfo.value.status_code == 401
+    assert excinfo.value.detail == "X-API-Key manquante"
+
+
+def test_get_current_user_api_key_invalid_key(monkeypatch):
+    monkeypatch.setenv("DISABLE_AUTH", "false")
+    monkeypatch.setattr(UtilisateurRepository, "get_by_api_key", lambda db, api_key: None)
+
+    with pytest.raises(HTTPException) as excinfo:
+        get_current_user_api_key(api_key="bad-key", db=object())
+
+    assert excinfo.value.status_code == 401
+    assert excinfo.value.detail == "X-API-Key invalide"
+
+
+def test_get_current_user_api_key_valid(monkeypatch):
+    monkeypatch.setenv("DISABLE_AUTH", "false")
+    user = DummyUser(role=DummyRole("ADMIN"))
+    monkeypatch.setattr(UtilisateurRepository, "get_by_api_key", lambda db, api_key: user)
+
+    result = get_current_user_api_key(api_key="valid-key", db=object())
+
+    assert result is user
+
+
+def test_require_roles_allows_authorized_role(monkeypatch):
+    monkeypatch.setenv("DISABLE_AUTH", "false")
+    dependency = require_roles("ADMIN", "MANAGER")
+    user = DummyUser(role=DummyRole("ADMIN"))
+
+    assert dependency(current_user=user) is user
+
+
+def test_require_roles_forbidden_for_unauthorized_role(monkeypatch):
+    monkeypatch.setenv("DISABLE_AUTH", "false")
+    dependency = require_roles("ADMIN")
+    user = DummyUser(role=DummyRole("USER"))
+
+    with pytest.raises(HTTPException) as excinfo:
+        dependency(current_user=user)
+
+    assert excinfo.value.status_code == 403
+    assert excinfo.value.detail == "Accès interdit"
+
+
+def test_require_roles_disabled_auth_returns_user(monkeypatch):
+    monkeypatch.setenv("DISABLE_AUTH", "true")
+    dependency = require_roles("ADMIN")
+    user = DummyUser(role=DummyRole("USER"))
+
+    assert dependency(current_user=user) is user

--- a/tests/test_password_utils.py
+++ b/tests/test_password_utils.py
@@ -1,0 +1,16 @@
+from src.utils.password import hash_password, verify_password
+
+
+def test_hash_and_verify_password_roundtrip():
+    password = "super-secret"
+    hashed = hash_password(password)
+
+    assert hashed != password
+    assert verify_password(password, hashed) is True
+
+
+def test_verify_password_rejects_wrong_password():
+    password = "super-secret"
+    hashed = hash_password(password)
+
+    assert verify_password("wrong-password", hashed) is False


### PR DESCRIPTION
### Motivation
- Ajouter des tests unitaires pour couvrir la logique d'authentification par clé API (`get_current_user_api_key`) et la protection par rôle (`require_roles`), ainsi que pour les utilitaires de mot de passe (`hash_password`, `verify_password`) afin d'améliorer la fiabilité et la couverture.

### Description
- Ajout de `tests/test_dependencies.py` (tests pour `get_current_user_api_key` et `require_roles`) et `tests/test_password_utils.py` (tests de hachage/vérification); les fichiers ont été ajoutés et committés.

### Testing
- Exécution automatisée tentée avec `python -m pytest -q tests/test_password_utils.py tests/test_dependencies.py` — exécution interrompue par une erreur d'import `ImportError: email-validator is not installed` provenant de Pydantic; aucun des tests ciblés n'a pu être exécuté avec succès en l'état.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6980ca768618832cb58caef9d18d924c)